### PR TITLE
Check command sent to the plugin

### DIFF
--- a/scaleover_plugin.go
+++ b/scaleover_plugin.go
@@ -73,7 +73,12 @@ func (cmd *ScaleoverCmd) parseTime(duration string) (time.Duration, error) {
 }
 
 func (cmd *ScaleoverCmd) Run(cliConnection plugin.CliConnection, args []string) {
+	if args[0] == "scaleover" {
+		cmd.ScaleoverCommand(cliConnection, args)
+	}
+}
 
+func (cmd *ScaleoverCmd) ScaleoverCommand(cliConnection plugin.CliConnection, args []string) {
 	err := cmd.usage(args)
 	if nil != err {
 		fmt.Println(err)


### PR DESCRIPTION
This is a good pattern for plugins that implement multiple commands,
but it also needs to be done for single command plugins to avoid a
usage error on uninstall, since at that time the plugin gets invoked
with the special command CLI-MESSAGE-UNINSTALL.

Fixes #10
