### PR TITLE
Proper handling of "Nothing to do"

### DIFF
--- a/scaleover_plugin.go
+++ b/scaleover_plugin.go
@@ -107,6 +107,10 @@ func (cmd *ScaleoverCmd) ScaleoverCommand(cliConnection plugin.CliConnection, ar
 	cmd.showStatus()
 
 	count := cmd.app1.countRequested
+	if (count == 0) {
+		fmt.Println("There are no instances of the source app to scale over")
+		os.Exit(0)
+	}
 	sleepInterval := time.Duration(rolloverTime.Nanoseconds() / int64(count))
 
 	for count > 0 {


### PR DESCRIPTION
Rather than silently panic with a division by zero, test for the
"nothing to do" condition and exit with status 0 and a friendly
message.

Fixes #12
